### PR TITLE
Modify solana intent execution to use a single transaction

### DIFF
--- a/example_solver/src/main.rs
+++ b/example_solver/src/main.rs
@@ -262,8 +262,10 @@ async fn handle_result_message(parsed: Value) {
             };
 
             // Log errors if any
-            if let Err(e) = result {
-                eprintln!("Error executing chain handler: {:?}", e);
+            match result {
+                Err(e) => eprintln!("Error spawning chain handler: {:?}", e),
+                Ok(Err(e)) => eprintln!("Error during chain handler execution: {}", e),
+                _ => {}
             }
 
             // Update INTENTS after execution


### PR DESCRIPTION
# Solana intent execution changes

**TODO:** Handle transaction too large condition and compute/heap limits.

In the previous implementation:

- When `solana_transfer_swap` was invoked, it would create a transfer or swap transaction.
- When `solana_send_funds_to_user` was invoked, it would create a transaction to send the funds to the user and optionally the solver.
- If the `token_in` was not USDT, we would create an extra swap transaction to convert it to USDT.
- Depending on the provided intent, we would create up to three separate transactions.

In the current implementation:

- The `solana_transfer_swap` function has been modified to return instructions instead of creating transactions.
- The `solana_send_funds_to_user` function has been modified to return instrutions instead of creating transactions.
- The `transfer_spl20` function has been modified to return instructions instead of creating transactions.
- The instructions are collected into a single combined transaction inside the `handle_solana_execution` function.
- The final transaction uses the `submit` function with Jito integration.
- Added a new `jupiter_swap_instructions` function as an alternative function which returns instructions.
- Renamed `transfer_slp20` to `transfer_spl20`.
- Made use of the `spl_token::ID` constant instead of `pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")`.
- Made use of the intent's `amount_in` value to get the final `token_in` quote.