### PR TITLE
Execute Solana transactions atomically using Jito bundles

### DIFF
--- a/example_solver/Cargo.lock
+++ b/example_solver/Cargo.lock
@@ -2415,6 +2415,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 3.0.4",
  "spl-token 3.5.0",
+ "spl-token-2022 0.9.0",
  "strum 0.26.2",
  "strum_macros 0.26.4",
  "thiserror",

--- a/example_solver/Cargo.toml
+++ b/example_solver/Cargo.toml
@@ -16,6 +16,7 @@ ethers = { version = "2.0.14", default-features = true, features = ["ws","abigen
 hex = "0.4.3"
 spl-associated-token-account = { version = "3.0.2", default-features = false, features = ["no-entrypoint"] }
 spl-token = { version = "3.2.0", default-features = false, features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.9.0", features = ["no-entrypoint"] }
 solana-client = "1.8.3"
 anchor-client = { version = "0.29.0" }
 solana-sdk = "1.17.30"

--- a/example_solver/src/chains/mod.rs
+++ b/example_solver/src/chains/mod.rs
@@ -2,16 +2,16 @@ pub mod ethereum;
 pub mod mantis;
 pub mod solana;
 
-use lazy_static::lazy_static;
-use std::collections::HashMap;
-
 use crate::env;
 use ethers::prelude::*;
 use ethers::signers::LocalWallet;
 use ethers::utils::hash_message;
 use ethers::utils::keccak256;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use solana::solana_chain;
+use std::collections::HashMap;
 use std::error::Error;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -117,10 +117,7 @@ lazy_static! {
             Blockchain::Ethereum,
             "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         );
-        usdt_addresses.insert(
-            Blockchain::Solana,
-            "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-        );
+        usdt_addresses.insert(Blockchain::Solana, solana_chain::USDT_ADDRESS);
         m.insert(
             Token::USDT,
             TokenInfo {

--- a/example_solver/src/chains/solana.rs
+++ b/example_solver/src/chains/solana.rs
@@ -1,6 +1,5 @@
 pub mod solana_chain {
     use crate::chains::*;
-    use crate::routers::jupiter::create_token_account;
     use crate::routers::jupiter::jupiter_swap;
     use crate::routers::jupiter::quote;
     use crate::routers::jupiter::Memo as Jup_Memo;
@@ -8,38 +7,110 @@ pub mod solana_chain {
     use crate::routers::jupiter::SwapMode;
     use crate::PostIntentInfo;
     use anchor_client::Cluster;
-    use anyhow::anyhow;
     use jito_protos::searcher::SubscribeBundleResultsRequest;
     use num_bigint::BigInt;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use solana_client::rpc_config::RpcSendTransactionConfig;
+    use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::commitment_config::CommitmentConfig;
     use solana_sdk::compute_budget::ComputeBudgetInstruction;
+    use solana_sdk::instruction::Instruction;
+    use solana_sdk::message::{v0, VersionedMessage};
+    use solana_sdk::pubkey;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::Signature;
     use solana_sdk::signature::{Keypair, Signer};
+    use solana_sdk::system_instruction;
+    use solana_sdk::system_program;
+    use solana_sdk::transaction::{Transaction, VersionedTransaction};
     use spl_associated_token_account::get_associated_token_address;
+    use spl_associated_token_account::instruction;
     use spl_token::instruction::transfer;
     use std::env;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
-    use std::thread::sleep;
     use std::time::Duration;
     use strum_macros::{Display, IntoStaticStr};
-    use {
-        solana_client::nonblocking::rpc_client::RpcClient,
-        solana_sdk::{instruction::Instruction, transaction::Transaction},
-    };
 
-    pub const JITO_ADDRESS: Pubkey =
-        solana_program::pubkey!("96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5");
+    pub const JITO_ADDRESS: Pubkey = pubkey!("96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5");
+    pub const AUCTIONEER_ADDRESS: Pubkey = pubkey!("5zCZ3jk8EZnJyG7fhDqD6tmqiYTLZjik5HUpGMnHrZfC");
     pub const JITO_TIP_AMOUNT: u64 = 100_000;
     pub const JITO_BLOCK_ENGINE_URL: &str = "https://mainnet.block-engine.jito.wtf";
-    pub const RETRIES: u8 = 1;
+    pub const MAX_RETRIES: u8 = 1;
+    pub const WSOL_ADDRESS: &str = "So11111111111111111111111111111111111111112";
+    pub const USDT_ADDRESS: &str = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
     pub static SUBMIT_THROUGH_JITO: AtomicBool = AtomicBool::new(option_env!("JITO").is_some());
+    const AUCTIONEER_URL: &str = "http://34.78.217.187:8080";
 
+    /// The Errors that may occur while using this module
+    #[derive(thiserror::Error, Debug)]
+    pub enum Error {
+        #[error("Soalana client error: {0}")]
+        SolanaClient(#[from] solana_client::client_error::ClientError),
+
+        #[error("Reqwest HTTP error: {0}")]
+        Reqwest(#[from] reqwest::Error),
+
+        #[error("Jito client error: {0}")]
+        JitoClient(#[from] jito_searcher_client::BlockEngineConnectionError),
+
+        #[error("Message compile error: {0}")]
+        MessageCompile(#[from] solana_sdk::message::CompileError),
+
+        #[error("Signer error: {0}")]
+        Signer(#[from] solana_sdk::signature::SignerError),
+
+        #[error("Program error: {0}")]
+        Program(#[from] solana_program::program_error::ProgramError),
+
+        #[error("Failed to parse {name}: {source}")]
+        ParseInt {
+            name: String,
+            #[source]
+            source: std::num::ParseIntError,
+        },
+
+        #[error("Failed to parse {name}: {source}")]
+        ParsePubkey {
+            name: String,
+            #[source]
+            source: solana_program::pubkey::ParsePubkeyError,
+        },
+
+        #[error("Env var must be set: {name} {source}")]
+        EnvVar {
+            name: String,
+            #[source]
+            source: std::env::VarError,
+        },
+
+        #[error("{0}")]
+        Message(String),
+
+        #[error("{context}: {source}")]
+        WithContext {
+            context: String,
+            #[source]
+            source: Box<dyn std::error::Error + Send + Sync>,
+        },
+    }
+
+    impl Error {
+        pub fn with_context<E>(context: &str, source: E) -> Self
+        where
+            E: std::error::Error + Send + Sync + 'static,
+        {
+            Error::WithContext {
+                context: context.to_string(),
+                source: Box::new(source),
+            }
+        }
+    }
+
+    type Result<T> = std::result::Result<T, Error>;
+
+    #[allow(clippy::upper_case_acronyms)]
     #[derive(Debug, Clone, Copy, Default, EnumString, Display, IntoStaticStr)]
     #[strum(serialize_all = "snake_case")]
     pub enum TxSendMethod {
@@ -70,81 +141,96 @@ pub mod solana_chain {
         intent: &PostIntentInfo,
         intent_id: &str,
         amount: &str,
-    ) -> Result<(), String> {
-        let from_keypair = Arc::new(Keypair::from_base58_string(
+    ) -> Result<()> {
+        let solver_keypair = Arc::new(Keypair::from_base58_string(
             env::var("SOLANA_KEYPAIR")
-                .expect("SOLANA_KEYPAIR must be set")
+                .map_err(|e| Error::EnvVar {
+                    name: "SOLANA_KEYPAIR".into(),
+                    source: e,
+                })?
                 .as_str(),
         ));
-        let rpc_url = env::var("SOLANA_RPC").expect("SOLANA_RPC must be set");
+        let rpc_url = env::var("SOLANA_RPC").map_err(|e| Error::EnvVar {
+            name: "SOLANA_RPC".into(),
+            source: e,
+        })?;
         let client = RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
 
-        let usdt_contract_address = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
-
-        // let usdt_token_account = get_associated_token_address(
-        //     &from_keypair.pubkey(),
-        //     &Pubkey::from_str(usdt_contract_address).unwrap(),
+        // let solver_usdt_ata = get_associated_token_address(
+        //     &solver_keypair.pubkey(),
+        //     &Pubkey::from_str(USDT_ADDRESS).unwrap(),
         // );
 
         // let balance_ant = client
-        //     .get_token_account_balance(&usdt_token_account)
+        //     .get_token_account_balance(&solver_usdt_ata)
         //     .await
-        //     .map_err(|e| format!("Failed to get token account balance: {}", e))?
+        //     .map_err(|e| Error::with_context("Failed to get solver USDT token account balance", e))?
         //     .ui_amount
         //     .unwrap();
 
         let mut user_account = String::default();
         let mut token_in = String::default();
+        let mut amount_in = String::default();
         let mut token_out = String::default();
 
         if let OperationOutput::SwapTransfer(transfer_output) = &intent.outputs {
             user_account = transfer_output.dst_chain_user.clone();
             token_out = transfer_output.token_out.clone();
 
-            if token_out == "11111111111111111111111111111111" {
-                token_out = "So11111111111111111111111111111111111111112".to_string();
+            if token_out == system_program::ID.to_string() {
+                token_out = WSOL_ADDRESS.to_string();
             }
         }
         if let OperationInput::SwapTransfer(transfer_input) = &intent.inputs {
             token_in = transfer_input.token_in.clone();
+            amount_in = transfer_input.amount_in.clone();
         }
 
         // swap USDT -> token_out
-        let token_out_account = get_associated_token_address(
-            &from_keypair.pubkey(),
-            &Pubkey::from_str(&token_out).unwrap(),
+        let solver_token_out_account = get_associated_token_address(
+            &solver_keypair.pubkey(),
+            &Pubkey::from_str(&token_out).map_err(|e| Error::ParsePubkey {
+                name: "token_out".into(),
+                source: e,
+            })?,
         );
 
-        let balance = client
-            .get_token_account_balance(&token_out_account)
+        let solver_token_out_balance = client
+            .get_token_account_balance(&solver_token_out_account)
             .await
             .map(|result| result.amount)
-            .unwrap_or_else(|_| "0".to_string());
+            .unwrap_or_else(|_| "0".to_string())
+            .parse::<u64>()
+            .map_err(|e| Error::ParseInt {
+                name: "balance".into(),
+                source: e,
+            })?;
 
-        if balance.parse::<u64>().unwrap() < amount.parse::<u64>().unwrap()
-            && !token_out.eq_ignore_ascii_case(usdt_contract_address)
+        let token_out_amount = amount.parse::<u64>().map_err(|e| Error::ParseInt {
+            name: "amount".into(),
+            source: e,
+        })?;
+
+        let mut setup_instructions: Vec<Instruction> = vec![];
+        let mut bundle_instructions: Vec<Vec<Instruction>> = vec![];
+
+        if solver_token_out_balance < token_out_amount
+            && !token_out.eq_ignore_ascii_case(USDT_ADDRESS)
         {
-            let mut attempts = 0;
-            let max_attempts = 3;
-
-            while attempts < max_attempts {
-                match solana_transfer_swap(intent.clone(), amount).await {
-                    Ok(_) => {
-                        // Successful execution, exit the loop
-                        break;
-                    }
-                    Err(e) => {
-                        attempts += 1;
-                        if attempts >= max_attempts {
-                            return Err(format!(
-                                "Error occurred on Solana swap USDT -> token_out (manual swap required) after {} attempts: {}",
-                                attempts, e
-                            ));
-                        }
-                        // Optional: Add a delay before retrying
-                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    }
-                }
+            let ts_instructions =
+                solana_transfer_swap(intent.clone(), amount)
+                    .await
+                    .map_err(|e| {
+                        Error::with_context(
+                        "Error occurred during swap from USDT to token_out (manual swap required)",
+                        e,
+                    )
+                    })?;
+            setup_instructions.extend(ts_instructions.setup_instructions);
+            if !ts_instructions.swap_instructions.is_empty() {
+                bundle_instructions.push(ts_instructions.swap_instructions);
+            } else if !ts_instructions.transfer_instructions.is_empty() {
+                bundle_instructions.push(ts_instructions.transfer_instructions);
             }
         }
 
@@ -153,11 +239,11 @@ pub mod solana_chain {
         } else if intent.src_chain == "solana" {
             SOLVER_ADDRESSES.get(1).unwrap()
         } else {
-            panic!("chain not supported, this should't happen");
+            panic!("Chain not supported, this should't happen");
         };
 
         // solver -> token_out -> user | user -> token_in -> solver
-        if let Err(e) = solana_send_funds_to_user(
+        let sftu_instructions = solana_send_funds_to_user(
             intent_id,
             &token_in,
             &token_out,
@@ -165,70 +251,57 @@ pub mod solana_chain {
             solver_out.to_string(),
             intent.src_chain == intent.dst_chain,
             rpc_url,
-            Pubkey::from_str(&bridge_escrow::ID.to_string()).unwrap(),
-            amount.parse::<u64>().unwrap(),
+            bridge_escrow::ID,
+            token_out_amount,
         )
         .await
-        {
-            return Err(format!(
-                "Error occurred on send token_out -> user & user sends token_in -> solver: {}",
-                e
-            ));
-        }
-        // swap token_in -> USDT
-        if intent.src_chain == intent.dst_chain
-            && !token_in.eq_ignore_ascii_case(usdt_contract_address)
-        {
-            let token_in_account = get_associated_token_address(
-                &from_keypair.pubkey(),
-                &Pubkey::from_str(&token_in).unwrap(),
-            );
+        .map_err(|e| Error::with_context("Error occurred during solana_send_funds_to_user", e))?;
 
-            let amount_in = client
-                .get_token_account_balance(&token_in_account)
-                .await
-                .map(|result| result.amount)
-                .unwrap_or_else(|_| "0".to_string());
+        let mut sftu_tx_index: Option<usize> = None;
+        setup_instructions.extend(sftu_instructions.setup_instructions);
+        if !sftu_instructions.send_funds_to_user_instructions.is_empty() {
+            bundle_instructions.push(sftu_instructions.send_funds_to_user_instructions);
+            // We record the SendFundsToUser transaction index to later find the correct signature.
+            sftu_tx_index = Some(bundle_instructions.len());
+        }
+
+        // swap token_in -> USDT
+        if intent.src_chain == intent.dst_chain && !token_in.eq_ignore_ascii_case(USDT_ADDRESS) {
+            let mut amount_in = amount_in.parse::<u64>().map_err(|e| Error::ParseInt {
+                name: "amount_in".into(),
+                source: e,
+            })?;
+            // The bridge escrow contract takes a 0.1% fee.
+            amount_in -= amount_in / 1000;
 
             let memo = format!(
                 r#"{{"user_account": "{}","token_in": "{}","token_out": "{}","amount": {},"slippage_bps": {}}}"#,
                 SOLVER_ADDRESSES.get(1).unwrap(),
                 token_in,
-                usdt_contract_address,
+                USDT_ADDRESS,
                 amount_in,
                 1000
             );
 
-            sleep(Duration::from_secs(2));
-            let mut attempts = 0;
-            let max_attempts = 2;
+            let js_instructions = jupiter_swap(
+                &memo,
+                &client,
+                solver_keypair.clone(),
+                SwapMode::ExactIn,
+                true,
+            )
+            .await
+            .map_err(|e| Error::Message(format!("Failed to swap token_in to USDT: {e}")))?;
 
-            while attempts < max_attempts {
-                match jupiter_swap(&memo, &client, from_keypair.clone(), SwapMode::ExactIn).await {
-                    Ok(_) => {
-                        // Successful execution, exit the loop
-                        break;
-                    }
-                    Err(e) => {
-                        attempts += 1;
-                        if attempts >= max_attempts {
-                            return Err(format!(
-                                "Error on Solana swap token_in -> USDT after {} attempts: {e}",
-                                attempts
-                            ));
-                        }
-                        // Optional: Add a delay before retrying
-                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    }
-                }
+            setup_instructions.extend(js_instructions.setup_instructions);
+            if !js_instructions.swap_instructions.is_empty() {
+                bundle_instructions.push(js_instructions.swap_instructions);
             }
-        } else {
-            // println!("You sent token_out to user for intent_id {intent_id}. You will receive token_in from user on src_chain");
         }
 
         // if intent.src_chain == intent.dst_chain {
         //     let mut balance_post = client
-        //         .get_token_account_balance(&usdt_token_account)
+        //         .get_token_account_balance(&solver_usdt_ata)
         //         .await
         //         .unwrap()
         //         .ui_amount
@@ -241,7 +314,7 @@ pub mod solana_chain {
         //     } else {
         //         std::thread::sleep(Duration::from_secs(5));
         //         balance_post = client
-        //             .get_token_account_balance(&usdt_token_account)
+        //             .get_token_account_balance(&solver_usdt_ata)
         //             .await
         //             .unwrap()
         //             .ui_amount
@@ -260,19 +333,71 @@ pub mod solana_chain {
         //         balance
         //     );
         // }
-        println!("intent {intent_id} solved");
 
-        Ok(())
+        match submit_through_jito(
+            &client,
+            solver_keypair,
+            setup_instructions,
+            bundle_instructions,
+            JITO_TIP_AMOUNT,
+        )
+        .await
+        {
+            Ok(bundle_signatures) => {
+                if let Some(index) = sftu_tx_index {
+                    let sftu_tx_hash = bundle_signatures[index];
+                    println!(
+                        "Sending SendFundsToUser transaction hash to auctioneer: {}",
+                        sftu_tx_hash
+                    );
+                    send_tx_hash_to_auctioneer(AUCTIONEER_URL, sftu_tx_hash)
+                        .await
+                        .map_err(|e| {
+                            Error::with_context("Failed to send transaction hash to auctioneer", e)
+                        })?;
+                } else {
+                    return Err(Error::Message(
+                        "SendFundsToUser signature index missing".into(),
+                    ));
+                }
+                println!("Intent {intent_id} solved successfully");
+                Ok(())
+            }
+            Err(error) => Err(Error::with_context(
+                "Failed to submit intent transactions",
+                error,
+            )),
+        }
     }
 
-    pub async fn solana_transfer_swap(intent: PostIntentInfo, amount: &str) -> Result<(), String> {
-        let rpc_url = env::var("SOLANA_RPC").map_err(|_| "SOLANA_RPC must be set".to_string())?;
+    #[derive(Debug, Default)]
+    pub struct TransferSwapInstructions {
+        pub setup_instructions: Vec<Instruction>,
+        pub transfer_instructions: Vec<Instruction>,
+        pub swap_instructions: Vec<Instruction>,
+    }
 
-        let from_keypair_str =
-            env::var("SOLANA_KEYPAIR").map_err(|_| "SOLANA_KEYPAIR must be set".to_string())?;
-        let from_keypair = Arc::new(Keypair::from_base58_string(&from_keypair_str));
+    pub async fn solana_transfer_swap(
+        intent: PostIntentInfo,
+        amount: &str,
+    ) -> Result<TransferSwapInstructions> {
+        let rpc_url = env::var("SOLANA_RPC").map_err(|e| Error::EnvVar {
+            name: "SOLANA_RPC".into(),
+            source: e,
+        })?;
+
+        let solver_keypair = Arc::new(Keypair::from_base58_string(
+            env::var("SOLANA_KEYPAIR")
+                .map_err(|e| Error::EnvVar {
+                    name: "SOLANA_KEYPAIR".into(),
+                    source: e,
+                })?
+                .as_str(),
+        ));
 
         let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+        let mut ts_instructions = TransferSwapInstructions::default();
 
         match intent.function_name.as_str() {
             "transfer" => {
@@ -283,23 +408,34 @@ pub mod solana_chain {
                 if let OperationOutput::SwapTransfer(transfer_output) = &intent.outputs {
                     user_account = transfer_output.dst_chain_user.clone();
                     token_out = transfer_output.token_out.clone();
-                    parsed_amount = transfer_output
-                        .amount_out
-                        .parse::<u64>()
-                        .map_err(|e| format!("Failed to parse amount_out: {}", e))?;
+                    parsed_amount =
+                        transfer_output
+                            .amount_out
+                            .parse::<u64>()
+                            .map_err(|e| Error::ParseInt {
+                                name: "amount_out".into(),
+                                source: e,
+                            })?;
                 }
 
-                transfer_slp20(
+                let instructions = transfer_spl20(
                     &client,
-                    from_keypair.clone(),
-                    &Pubkey::from_str(&user_account)
-                        .map_err(|e| format!("Invalid user_account pubkey: {}", e))?,
-                    &Pubkey::from_str(&token_out)
-                        .map_err(|e| format!("Invalid token_out pubkey: {}", e))?,
+                    solver_keypair.clone(),
+                    &Pubkey::from_str(&user_account).map_err(|e| Error::ParsePubkey {
+                        name: "user_account".into(),
+                        source: e,
+                    })?,
+                    &Pubkey::from_str(&token_out).map_err(|e| Error::ParsePubkey {
+                        name: "token_out".into(),
+                        source: e,
+                    })?,
                     parsed_amount,
                 )
                 .await
-                .map_err(|err| format!("Transaction failed: {}", err))?;
+                .map_err(|e| Error::with_context("Token transfer failed", e))?;
+
+                ts_instructions.setup_instructions = instructions.setup_instructions;
+                ts_instructions.transfer_instructions = instructions.transfer_instructions;
             }
             "swap" => {
                 let mut token_out = String::default();
@@ -309,72 +445,81 @@ pub mod solana_chain {
                 }
 
                 let memo = format!(
-                    r#"{{"user_account": "{}","token_in": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB","token_out": "{}","amount": {},"slippage_bps": {}}}"#,
+                    r#"{{"user_account": "{}","token_in": "{}","token_out": "{}","amount": {},"slippage_bps": {}}}"#,
                     SOLVER_ADDRESSES.get(1).unwrap(),
+                    USDT_ADDRESS,
                     token_out,
                     amount,
                     200
                 );
 
-                jupiter_swap(&memo, &client, from_keypair.clone(), SwapMode::ExactOut)
-                    .await
-                    .map_err(|err| format!("Swap failed: {}", err))?;
+                let js_instructions = jupiter_swap(
+                    &memo,
+                    &client,
+                    solver_keypair.clone(),
+                    SwapMode::ExactOut,
+                    true,
+                )
+                .await
+                .map_err(|e| Error::Message(format!("Jupiter swap failed: {e}")))?;
+
+                ts_instructions.setup_instructions = js_instructions.setup_instructions;
+                ts_instructions.swap_instructions = js_instructions.swap_instructions;
             }
             _ => {
-                return Err("Function not supported".to_string());
+                return Err(Error::Message("Function not supported".into()));
             }
         };
 
-        Ok(())
+        Ok(ts_instructions)
     }
 
-    async fn transfer_slp20(
+    #[derive(Debug, Default)]
+    struct TransferSPL20Instructions {
+        setup_instructions: Vec<Instruction>,
+        transfer_instructions: Vec<Instruction>,
+    }
+
+    async fn transfer_spl20(
         client: &RpcClient,
         sender_keypair: Arc<Keypair>,
-        recipient_wallet_pubkey: &Pubkey,
-        token_mint_pubkey: &Pubkey,
+        recipient_wallet: &Pubkey,
+        token_mint: &Pubkey,
         amount: u64,
-    ) -> Result<String, Box<dyn std::error::Error>> {
-        let sender_wallet_pubkey = &sender_keypair.pubkey();
-        let sender_token_account_pubkey =
-            get_associated_token_address(sender_wallet_pubkey, token_mint_pubkey);
-        let recipient_token_account_pubkey =
-            get_associated_token_address(recipient_wallet_pubkey, token_mint_pubkey);
+    ) -> Result<TransferSPL20Instructions> {
+        let sender_wallet = &sender_keypair.pubkey();
+        let sender_token_account = get_associated_token_address(sender_wallet, token_mint);
+        let recipient_token_account = get_associated_token_address(recipient_wallet, token_mint);
 
-        if client
-            .get_account(&sender_token_account_pubkey)
-            .await
-            .is_err()
-        {
+        if client.get_account(&sender_token_account).await.is_err() {
             eprintln!("Sender's associated token account does not exist");
-            return Err("Sender's associated token account does not exist".into());
+            return Err(Error::Message(
+                "Sender's associated token account does not exist".into(),
+            ));
         }
 
-        if client
-            .get_account(&recipient_token_account_pubkey)
-            .await
-            .is_err()
-        {
-            create_token_account(
-                recipient_wallet_pubkey,
-                token_mint_pubkey,
-                sender_keypair.clone(),
-                client,
-            )
-            .await
-            .unwrap();
+        let mut setup_instructions: Vec<Instruction> = vec![];
+        if client.get_account(&recipient_token_account).await.is_err() {
+            let token_program_id = get_token_program_id(client, token_mint).await?;
+            setup_instructions.push(instruction::create_associated_token_account_idempotent(
+                &sender_keypair.pubkey(),
+                recipient_wallet,
+                token_mint,
+                &token_program_id,
+            ));
         }
 
-        let recent_blockhash = client.get_latest_blockhash().await.unwrap();
+        let mut transfer_instructions: Vec<Instruction> = vec![];
+        let recent_blockhash = client.get_latest_blockhash().await?;
         let transfer_instruction = transfer(
             &spl_token::id(),
-            &sender_token_account_pubkey,
-            &recipient_token_account_pubkey,
+            &sender_token_account,
+            &recipient_token_account,
             &sender_keypair.pubkey(),
             &[],
             amount,
-        )
-        .unwrap();
+        )?;
+        transfer_instructions.push(transfer_instruction.clone());
 
         let transaction = Transaction::new_signed_with_payer(
             &[transfer_instruction],
@@ -383,26 +528,26 @@ pub mod solana_chain {
             recent_blockhash,
         );
 
-        let simulation_result = client.simulate_transaction(&transaction).await.unwrap();
+        let simulation_result = client.simulate_transaction(&transaction).await?;
         if simulation_result.value.err.is_some() {
             eprintln!(
                 "Transaction simulation failed: {:?}",
                 simulation_result.value.err
             );
-            return Err("Transaction simulation failed".into());
+            return Err(Error::Message("Transaction simulation failed".into()));
         }
 
-        let result = client
-            .send_and_confirm_transaction_with_spinner(&transaction)
-            .await?;
-
-        Ok(result.to_string())
+        Ok(TransferSPL20Instructions {
+            setup_instructions,
+            transfer_instructions,
+        })
     }
 
-    pub async fn _get_solana_token_decimals(
-        token_address: &str,
-    ) -> Result<u8, Box<dyn std::error::Error>> {
-        let rpc_url = env::var("SOLANA_RPC").expect("SOLANA_RPC must be set");
+    pub async fn _get_solana_token_decimals(token_address: &str) -> Result<u8> {
+        let rpc_url = env::var("SOLANA_RPC").map_err(|e| Error::EnvVar {
+            name: "SOLANA_RPC".into(),
+            source: e,
+        })?;
         let client = reqwest::Client::new();
         let request_body = json!({
             "jsonrpc": "2.0",
@@ -424,7 +569,24 @@ pub mod solana_chain {
         if let Some(decimals) = response["result"]["value"]["decimals"].as_u64() {
             Ok(decimals as u8)
         } else {
-            Err("Token information not available.".into())
+            Err(Error::Message("Token information not available.".into()))
+        }
+    }
+
+    async fn get_token_program_id(rpc_client: &RpcClient, token_mint: &Pubkey) -> Result<Pubkey> {
+        let mint_account = rpc_client
+            .get_account(token_mint)
+            .await
+            .map_err(|e| Error::with_context("Failed to get token mint account", e))?;
+
+        if mint_account.owner == spl_token_2022::ID {
+            Ok(spl_token_2022::ID)
+        } else if mint_account.owner == spl_token::ID {
+            Ok(spl_token::ID)
+        } else {
+            Err(Error::Message(
+                "Token mint is not owned by Token or Token2022 program".into(),
+            ))
         }
     }
 
@@ -434,8 +596,8 @@ pub mod solana_chain {
         mut token_out: &str,
         amount_in: u64,
     ) -> String {
-        if token_out == "11111111111111111111111111111111" {
-            token_out = "So11111111111111111111111111111111111111112";
+        if token_out == system_program::ID.to_string() {
+            token_out = WSOL_ADDRESS;
         }
 
         let memo_json = json!({
@@ -466,6 +628,13 @@ pub mod solana_chain {
         BigInt::from(quotes.out_amount).to_string()
     }
 
+    #[derive(Debug, Default)]
+    pub struct SendFundsToUserInstructions {
+        pub setup_instructions: Vec<Instruction>,
+        pub send_funds_to_user_instructions: Vec<Instruction>,
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub async fn solana_send_funds_to_user(
         intent_id: &str,
         token_in_mint: &str,
@@ -476,71 +645,73 @@ pub mod solana_chain {
         rpc_url: String,
         program_id: Pubkey,
         amount_out_cross_chain: u64,
-    ) -> Result<(), String> {
-        // Load the keypair from environment variable
-        let solana_keypair = env::var("SOLANA_KEYPAIR")
-            .map_err(|e| format!("Failed to read SOLANA_KEYPAIR from environment: {}", e))?;
-
-        let solver = Arc::new(Keypair::from_base58_string(&solana_keypair));
+    ) -> Result<SendFundsToUserInstructions> {
+        let solver_keypair = Arc::new(Keypair::from_base58_string(
+            env::var("SOLANA_KEYPAIR")
+                .map_err(|e| Error::EnvVar {
+                    name: "SOLANA_KEYPAIR".into(),
+                    source: e,
+                })?
+                .as_str(),
+        ));
 
         // Clone the necessary variables for the task
-        let solver_clone = Arc::clone(&solver);
+        let solver_clone = Arc::clone(&solver_keypair);
         let intent_id = intent_id.to_string();
-        let token_in_mint = token_in_mint.to_string();
-        let token_out_mint = token_out_mint.to_string();
-        let user = user.to_string();
+        let token_in_mint = Pubkey::from_str(token_in_mint).map_err(|e| Error::ParsePubkey {
+            name: "token_in_mint".into(),
+            source: e,
+        })?;
+        let token_out_mint = Pubkey::from_str(token_out_mint).map_err(|e| Error::ParsePubkey {
+            name: "token_out_mint".into(),
+            source: e,
+        })?;
+        let user = Pubkey::from_str(user).map_err(|e| Error::ParsePubkey {
+            name: "user".into(),
+            source: e,
+        })?;
 
         let rpc_client =
             RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
 
-        let solver_token_out_addr = get_associated_token_address(
-            &Pubkey::from_str(&user).unwrap(), // careful with cross-chain
-            &Pubkey::from_str(&token_out_mint).unwrap(),
+        let solver_token_out_ata = get_associated_token_address(
+            &user, // careful with cross-chain
+            &token_out_mint,
         );
 
+        let mut sftu_instructions = SendFundsToUserInstructions::default();
+
         if single_domain {
-            let solver_token_in_addr = get_associated_token_address(
-                &solver_clone.pubkey(),
-                &Pubkey::from_str(&token_in_mint).unwrap(),
+            let solver_token_in_ata =
+                get_associated_token_address(&solver_clone.pubkey(), &token_in_mint);
+
+            if rpc_client.get_account(&solver_token_in_ata).await.is_err() {
+                let token_program_id = get_token_program_id(&rpc_client, &token_in_mint).await?;
+                sftu_instructions.setup_instructions.push(
+                    instruction::create_associated_token_account_idempotent(
+                        &solver_keypair.pubkey(),
+                        &solver_clone.pubkey(),
+                        &token_in_mint,
+                        &token_program_id,
+                    ),
+                );
+            }
+        }
+
+        if rpc_client.get_account(&solver_token_out_ata).await.is_err() {
+            let token_program_id = get_token_program_id(&rpc_client, &token_out_mint).await?;
+            sftu_instructions.setup_instructions.push(
+                instruction::create_associated_token_account_idempotent(
+                    &solver_keypair.pubkey(),
+                    &user,
+                    &token_out_mint,
+                    &token_program_id,
+                ),
             );
-
-            if rpc_client
-                .get_token_account_balance(&solver_token_in_addr)
-                .await
-                .is_err()
-            {
-                if let Err(e) = create_token_account(
-                    &solver_clone.pubkey(),
-                    &Pubkey::from_str(&token_in_mint).unwrap(),
-                    solver.clone(),
-                    &rpc_client,
-                )
-                .await
-                {
-                    eprintln!("Failed to create token account: {}", e);
-                }
-            }
         }
 
-        if rpc_client
-            .get_token_account_balance(&solver_token_out_addr)
-            .await
-            .is_err()
-        {
-            if let Err(e) = create_token_account(
-                &Pubkey::from_str(&user).unwrap(),
-                &Pubkey::from_str(&token_out_mint).unwrap(),
-                solver.clone(),
-                &rpc_client,
-            )
-            .await
-            {
-                eprintln!("Failed to create token account: {}", e);
-            }
-        }
-
-        // Spawn a blocking task to execute the transaction
-        let instructions = tokio::task::block_in_place(|| {
+        // Spawn a blocking task to construct the transaction instructions
+        sftu_instructions.send_funds_to_user_instructions = tokio::task::block_in_place(|| {
             let client = anchor_client::Client::new_with_options(
                 Cluster::Custom(rpc_url.clone(), rpc_url),
                 solver_clone.clone(),
@@ -549,57 +720,47 @@ pub mod solana_chain {
 
             let program = client
                 .program(program_id)
-                .map_err(|e| format!("Failed to access bridge_escrow program: {}", e))?;
+                .map_err(|e| Error::with_context("Failed to access bridge_escrow program", e))?;
 
-            let user_token_out_addr = get_associated_token_address(
-                &Pubkey::from_str(&user).map_err(|e| format!("Invalid user pubkey: {}", e))?,
-                &Pubkey::from_str(&token_out_mint)
-                    .map_err(|e| format!("Invalid token_out_mint pubkey: {}", e))?,
-            );
+            let user_token_out_addr = get_associated_token_address(&user, &token_out_mint);
 
             let intent_state =
                 Pubkey::find_program_address(&[b"intent", intent_id.as_bytes()], &program_id).0;
 
             let auctioneer_state = Pubkey::find_program_address(&[b"auctioneer"], &program_id).0;
 
-            let solver_token_out_addr = get_associated_token_address(
-                &solver_clone.pubkey(),
-                &Pubkey::from_str(&token_out_mint)
-                    .map_err(|e| format!("Invalid token_out_mint pubkey: {}", e))?,
-            );
-
-            let solana_ibc_id =
-                Pubkey::from_str("2HLLVco5HvwWriNbUhmVwA2pCetRkpgrqwnjcsZdyTKT").unwrap();
+            let solver_token_out_addr =
+                get_associated_token_address(&solver_clone.pubkey(), &token_out_mint);
 
             let (_storage, _bump_storage) = Pubkey::find_program_address(
                 &[solana_ibc::SOLANA_IBC_STORAGE_SEED],
-                &solana_ibc_id,
+                &solana_ibc::ID,
             );
 
             let (_trie, _bump_trie) =
-                Pubkey::find_program_address(&[solana_ibc::TRIE_SEED], &solana_ibc_id);
+                Pubkey::find_program_address(&[solana_ibc::TRIE_SEED], &solana_ibc::ID);
 
             let (_chain, _bump_chain) =
-                Pubkey::find_program_address(&[solana_ibc::CHAIN_SEED], &solana_ibc_id);
+                Pubkey::find_program_address(&[solana_ibc::CHAIN_SEED], &solana_ibc::ID);
 
             let (_mint_authority, _bump_mint_authority) =
-                Pubkey::find_program_address(&[solana_ibc::MINT_ESCROW_SEED], &solana_ibc_id);
+                Pubkey::find_program_address(&[solana_ibc::MINT_ESCROW_SEED], &solana_ibc::ID);
 
             let _dummy_token_mint = Pubkey::find_program_address(&[b"dummy"], &program_id).0;
 
             let _hashed_full_denom =
-                lib::hash::CryptoHash::digest(&_dummy_token_mint.to_string().as_bytes());
+                lib::hash::CryptoHash::digest(_dummy_token_mint.to_string().as_bytes());
 
             let (_escrow_account, _bump_escrow_account) = Pubkey::find_program_address(
-                &[solana_ibc::ESCROW, &_hashed_full_denom.as_slice()],
-                &solana_ibc_id,
+                &[solana_ibc::ESCROW, _hashed_full_denom.as_slice()],
+                &solana_ibc::ID,
             );
 
             let _receiver_token_account =
-                get_associated_token_address(&solver.pubkey(), &_dummy_token_mint);
+                get_associated_token_address(&solver_keypair.pubkey(), &_dummy_token_mint);
 
             let (_fee_collector, _bump_fee_collector) =
-                Pubkey::find_program_address(&[solana_ibc::FEE_SEED], &solana_ibc_id);
+                Pubkey::find_program_address(&[solana_ibc::FEE_SEED], &solana_ibc::ID);
 
             let storage;
             let trie;
@@ -609,8 +770,6 @@ pub mod solana_chain {
             let escrow_account;
             let receiver_token_account;
             let fee_collector;
-            let auctioneer =
-                Pubkey::from_str("5zCZ3jk8EZnJyG7fhDqD6tmqiYTLZjik5HUpGMnHrZfC").unwrap();
 
             if !single_domain {
                 storage = Some(_storage);
@@ -628,9 +787,9 @@ pub mod solana_chain {
                     .accounts(bridge_escrow::accounts::SplTokenTransferCrossChain {
                         auctioneer_state,
                         solver: solver_clone.pubkey(),
-                        auctioneer: auctioneer,
+                        auctioneer: AUCTIONEER_ADDRESS,
                         token_in: None,
-                        token_out: Pubkey::from_str(&token_out_mint).unwrap(),
+                        token_out: token_out_mint,
                         auctioneer_token_in_account: None,
                         solver_token_in_account: None,
                         solver_token_out_account: solver_token_out_addr,
@@ -639,7 +798,7 @@ pub mod solana_chain {
                         associated_token_program: anchor_spl::associated_token::ID,
                         system_program: anchor_lang::solana_program::system_program::ID,
                         ibc_program: Some(solana_ibc::ID),
-                        receiver: Some(Pubkey::from_str(&user).unwrap()),
+                        receiver: Some(user),
                         storage: storage,
                         trie: trie,
                         chain: chain,
@@ -656,7 +815,12 @@ pub mod solana_chain {
                     })
                     .payer(solver_clone.clone())
                     .instructions()
-                    .map_err(|e| format!("Failed to create instructions: {}", e))
+                    .map_err(|e| {
+                        Error::with_context(
+                            "Failed to create instructions for SendFundsToUserCrossChain",
+                            e,
+                        )
+                    })
             } else {
                 storage = Some(_storage);
                 trie = Some(_trie);
@@ -665,18 +829,11 @@ pub mod solana_chain {
                 escrow_account = Some(_escrow_account);
                 receiver_token_account = Some(_receiver_token_account);
                 fee_collector = Some(_fee_collector);
-                let receiver = Some(
-                    Pubkey::from_str(&user).map_err(|e| format!("Invalid user pubkey: {}", e))?,
-                );
-                let token_in_escrow_addr = get_associated_token_address(
-                    &auctioneer_state,
-                    &Pubkey::from_str(&token_in_mint).unwrap(),
-                );
-                let solver_token_in_addr = get_associated_token_address(
-                    &solver_clone.pubkey(),
-                    &Pubkey::from_str(&token_in_mint)
-                        .map_err(|e| format!("Invalid token_out_mint pubkey: {}", e))?,
-                );
+                let receiver = Some(user);
+                let token_in_escrow_addr =
+                    get_associated_token_address(&auctioneer_state, &token_in_mint);
+                let solver_token_in_addr =
+                    get_associated_token_address(&solver_clone.pubkey(), &token_in_mint);
                 let auctioneer_token_in_account = Some(token_in_escrow_addr);
                 let solver_token_in_account = Some(solver_token_in_addr);
 
@@ -689,13 +846,9 @@ pub mod solana_chain {
                         intent: Some(intent_state),
                         intent_owner: receiver.unwrap(),
                         auctioneer_state,
-                        auctioneer: Pubkey::from_str(
-                            "5zCZ3jk8EZnJyG7fhDqD6tmqiYTLZjik5HUpGMnHrZfC",
-                        )
-                        .map_err(|e| format!("Invalid auctioneer pubkey: {}", e))?,
-                        token_in: Some(Pubkey::from_str(&token_in_mint).unwrap()),
-                        token_out: Pubkey::from_str(&token_out_mint)
-                            .map_err(|e| format!("Invalid token_out_mint pubkey: {}", e))?,
+                        auctioneer: AUCTIONEER_ADDRESS,
+                        token_in: Some(token_in_mint),
+                        token_out: token_out_mint,
                         auctioneer_token_in_account: auctioneer_token_in_account,
                         solver_token_in_account: solver_token_in_account,
                         solver_token_out_account: solver_token_out_addr,
@@ -719,20 +872,12 @@ pub mod solana_chain {
                     })
                     .payer(solver_clone.clone())
                     .instructions()
-                    .map_err(|e| format!("Failed to create instructions: {}", e))
+                    .map_err(|e| {
+                        Error::with_context("Failed to create instructions for SendFundsToUser", e)
+                    })
             }
         })?;
-
-        // Submit transaction asynchronously
-        let rpc_url = env::var("SOLANA_RPC").expect("SOLANA_RPC must be set");
-        let client = RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
-        match submit(&client, solver_clone, instructions, JITO_TIP_AMOUNT).await {
-            Ok(tx_hash) => {
-                let _ = send_tx_hash_to_auctioner("http://34.78.217.187:8080", tx_hash).await;
-                Ok(())
-            } // Transaction succeeded
-            Err(_) => Ok(()), // Return error if transaction fails
-        }
+        Ok(sftu_instructions)
     }
 
     pub async fn submit(
@@ -740,67 +885,80 @@ pub mod solana_chain {
         fee_payer: Arc<Keypair>,
         instructions: Vec<Instruction>,
         jito_tip: u64,
-    ) -> Result<Signature, String> {
+    ) -> Result<Signature> {
         let tx_send_method: TxSendMethod = match SUBMIT_THROUGH_JITO.load(Ordering::Relaxed) {
             true => TxSendMethod::JITO,
             false => TxSendMethod::RPC,
         };
         match tx_send_method {
             TxSendMethod::JITO => {
-                submit_through_jito(rpc_client, fee_payer, instructions, jito_tip).await
+                submit_through_jito(rpc_client, fee_payer, vec![], vec![instructions], jito_tip)
+                    .await
+                    .map(|signatures| signatures.first().cloned().unwrap())
             }
-            TxSendMethod::RPC => submit_default(rpc_client, fee_payer, instructions).await,
+            TxSendMethod::RPC => submit_default(rpc_client, fee_payer, instructions, true).await,
         }
-        .map_err(|e| e.to_string())
     }
 
     pub async fn submit_default(
         rpc_client: &RpcClient,
         fee_payer: Arc<Keypair>,
         instructions: Vec<Instruction>,
-    ) -> anyhow::Result<Signature> {
-        // let mut current_try = 0;
+        legacy_transaction: bool,
+    ) -> Result<Signature> {
+        let mut retries = 0;
         loop {
-            // current_try += 1;
+            let send_result;
+            if legacy_transaction {
+                let transaction = Transaction::new_signed_with_payer(
+                    &instructions,
+                    Some(&fee_payer.pubkey()),
+                    &[&*fee_payer],
+                    rpc_client.get_latest_blockhash().await?,
+                );
 
-            let recent_blockhash = rpc_client
-                .get_latest_blockhash()
-                .await
-                .map_err(|e| anyhow!("Failed to fetch blockhash: {}", e))?;
-            let transaction = Transaction::new_signed_with_payer(
-                &instructions,
-                Some(&fee_payer.pubkey()),
-                &[&*fee_payer],
-                recent_blockhash,
-            );
+                send_result = rpc_client
+                    .send_and_confirm_transaction_with_spinner(&transaction)
+                    .await;
+            } else {
+                let message = v0::Message::try_compile(
+                    &fee_payer.pubkey(),
+                    &instructions,
+                    &[],
+                    rpc_client.get_latest_blockhash().await?,
+                )?;
 
-            let sig = rpc_client
-                .send_and_confirm_transaction_with_spinner_and_config(
-                    &transaction,
-                    rpc_client.commitment(),
-                    RpcSendTransactionConfig {
-                        skip_preflight: true,
-                        ..Default::default()
-                    },
-                )
-                .await;
+                let transaction =
+                    VersionedTransaction::try_new(VersionedMessage::V0(message), &[&fee_payer])?;
 
-            match sig {
-                Ok(sig) => return Ok(sig), // Transaction succeeded, exit loop
-                Err(err) if err.to_string().contains("unable to confirm transaction") => {
-                    // eprintln!("Transaction failed: {}. Retrying...", err);
-                    return Err(anyhow!("Failed to send transaction: {}", err));
-                    // if current_try == RETRIES {
-                    //     return Err(anyhow!("Failed to send transaction: {}", err));
-                    // }
-                    // std::thread::sleep(Duration::from_secs(1));
+                send_result = rpc_client
+                    .send_and_confirm_transaction_with_spinner(&transaction)
+                    .await;
+            }
+
+            match send_result {
+                Ok(signature) => return Ok(signature),
+                Err(error) if error.to_string().contains("unable to confirm transaction") => {
+                    if retries == MAX_RETRIES {
+                        return Err(Error::with_context(
+                            "Reached maximum retries for transaction",
+                            error,
+                        ));
+                    }
+                    eprintln!("Sending transaction failed: {}", error);
+                    println!(
+                        "Retrying transaction {} more time(s)",
+                        MAX_RETRIES - retries
+                    );
+                    retries += 1;
+                    std::thread::sleep(Duration::from_secs(1));
                 }
-                Err(err) => {
-                    return Err(anyhow!(
-                        "Transaction failed due to a non-retryable error: {}",
-                        err
-                    ))
-                } // Break on other errors
+                Err(error) => {
+                    return Err(Error::with_context(
+                        "Transaction failed due to a non-retryable error",
+                        error,
+                    ));
+                }
             }
         }
     }
@@ -808,73 +966,113 @@ pub mod solana_chain {
     pub async fn submit_through_jito(
         rpc_client: &RpcClient,
         fee_payer: Arc<Keypair>,
-        instructions: Vec<Instruction>,
+        setup_instructions: Vec<Instruction>,
+        bundle_instructions: Vec<Vec<Instruction>>,
         jito_tip: u64,
-    ) -> anyhow::Result<Signature> {
-        let ix = anchor_lang::solana_program::system_instruction::transfer(
+    ) -> Result<Vec<Signature>> {
+        let recent_blockhash = rpc_client.get_latest_blockhash().await?;
+
+        let mut setup_with_tip_instructions = setup_instructions.clone();
+
+        let tip_instruction =
+            system_instruction::transfer(&fee_payer.pubkey(), &JITO_ADDRESS, jito_tip);
+
+        setup_with_tip_instructions.push(tip_instruction);
+
+        let setup_with_tip_message = v0::Message::try_compile(
             &fee_payer.pubkey(),
-            &JITO_ADDRESS,
-            jito_tip,
-        );
+            &setup_with_tip_instructions,
+            &[],
+            recent_blockhash,
+        )?;
 
-        let mut all_instructions = vec![ix];
-        all_instructions.extend_from_slice(instructions.as_slice());
+        let setup_with_tip_transaction = VersionedTransaction::try_new(
+            VersionedMessage::V0(setup_with_tip_message),
+            &[&fee_payer],
+        )?;
 
-        let tx =
-            Transaction::new_with_payer(all_instructions.as_slice(), Some(&fee_payer.pubkey()));
+        let mut bundle_transactions: Vec<VersionedTransaction> = vec![setup_with_tip_transaction];
 
-        let mut current_try = 0;
-        let mut signature: Signature = Signature::default();
-        while current_try < RETRIES {
-            let mut cloned_tx = tx.clone();
-            let mut client =
-                jito_searcher_client::get_searcher_client(&JITO_BLOCK_ENGINE_URL, &fee_payer)
-                    .await?;
-            let mut bundle_results_subscription = client
-                .subscribe_bundle_results(SubscribeBundleResultsRequest {})
-                .await?
-                .into_inner();
+        // Create a VersionedTransaction from each instruction group in the bundle.
+        for instructions in bundle_instructions.iter() {
+            let message =
+                v0::Message::try_compile(&fee_payer.pubkey(), instructions, &[], recent_blockhash)?;
+            let transaction =
+                VersionedTransaction::try_new(VersionedMessage::V0(message), &[&fee_payer])?;
+            bundle_transactions.push(transaction);
+        }
 
-            let blockhash = rpc_client.get_latest_blockhash().await?;
-            cloned_tx.sign(&[&*fee_payer], blockhash);
+        let mut client =
+            jito_searcher_client::get_searcher_client(JITO_BLOCK_ENGINE_URL, &fee_payer).await?;
 
-            let signatures = jito_searcher_client::send_bundle_with_confirmation(
-                &[cloned_tx.into()],
-                &rpc_client,
+        let mut bundle_results_subscription = client
+            .subscribe_bundle_results(SubscribeBundleResultsRequest {})
+            .await
+            .map_err(|e| Error::with_context("Failed to subscribe to bundle results", e))?
+            .into_inner();
+
+        let jito_bundle_result = if bundle_transactions.len() > 5 {
+            Err(Error::Message("Bundle has more than 5 transactions".into()))
+        } else {
+            let mut bundle_tx_signtures: Vec<Signature> = vec![];
+            bundle_transactions
+                .iter()
+                .for_each(|tx| bundle_tx_signtures.extend(tx.signatures.clone()));
+            println!(
+                "Sending Jito bundle with {} transactions: {:?}",
+                bundle_transactions.len(),
+                bundle_tx_signtures
+            );
+
+            jito_searcher_client::send_bundle_with_confirmation(
+                &bundle_transactions,
+                rpc_client,
                 &mut client,
                 &mut bundle_results_subscription,
             )
             .await
-            .or_else(|e| {
-                // println!("This is error {:?}", e);
-                Err(e)
-            });
+            .map_err(|e| Error::Message(e.to_string()))
+        };
 
-            if let Ok(sigs) = signatures {
-                signature = *sigs.first().unwrap();
-                return Ok(signature);
-            } else {
-                current_try += 1;
-                continue;
+        match jito_bundle_result {
+            Err(error) => {
+                eprintln!("Failed to send the Jito bundle: {error}");
+                let mut rpc_signatures: Vec<Signature> = vec![];
+                for (i, tx_instructions) in bundle_instructions.iter().enumerate() {
+                    println!(
+                        "Sending transaction {} of {} via RPC",
+                        i + 1,
+                        bundle_instructions.len()
+                    );
+                    let signature = submit_default(
+                        rpc_client,
+                        fee_payer.clone(),
+                        tx_instructions.to_vec(),
+                        false,
+                    )
+                    .await
+                    .map_err(|e| {
+                        Error::Message(format!(
+                            "Failed to submit transaction {} of {} via RPC: {e}",
+                            i + 1,
+                            bundle_instructions.len()
+                        ))
+                    })?;
+                    rpc_signatures.push(signature);
+                }
+                Ok(rpc_signatures)
             }
-        }
-        if current_try == RETRIES {
-            println!("Failed to send transaction with the tries, Sending it through RPC Now");
-            submit_default(rpc_client, fee_payer, instructions).await
-        } else {
-            Ok(signature)
+            Ok(jito_signatures) => Ok(jito_signatures),
         }
     }
 
-    async fn send_tx_hash_to_auctioner(
-        auctioner_url: &str,
-        tx_hash: Signature,
-    ) -> anyhow::Result<()> {
-        let _ = reqwest::Client::new()
-            .post(&format!("{auctioner_url}/solana_tx_proof"))
+    async fn send_tx_hash_to_auctioneer(auctioneer_url: &str, tx_hash: Signature) -> Result<()> {
+        let response = reqwest::Client::new()
+            .post(format!("{auctioneer_url}/solana_tx_proof"))
             .body(tx_hash.to_string())
             .send()
             .await?;
+        println!("Auctioneer response: {}", response.status());
         Ok(())
     }
 }

--- a/example_solver/src/routers/mod.rs
+++ b/example_solver/src/routers/mod.rs
@@ -11,6 +11,7 @@ use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use num_traits::Zero;
 use solana::solana_chain::solana_simulate_swap;
+use solana_sdk::system_program;
 use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
@@ -65,7 +66,7 @@ pub async fn get_simulate_swap_intent(
         OperationOutput::Borrow(_) => todo!(),
     };
 
-    if token_out == "11111111111111111111111111111111" {
+    if token_out == system_program::ID.to_string() {
         sleep(tokio::time::Duration::from_secs(2));
         return String::from("0");
     }


### PR DESCRIPTION
# Solana intent atomic execution

This PR implements the atomic execution of all solana transactions executed during intent processing.

Transactions are collected into a bundle and submited to the Jito relay using the provided Jito client.

If the Jito bundle fails, we fall back to the old way of executing individual transactions via RPC.

The code differentiates between `setup_instructions` such as creating associated token accounts or tipping, and `bundle_instructions` which cointain the main swap and transfer instructions.

This minimizes the amount of small transactions to stay under the 5 transaction limit in a Jito bundle.

List of changes in this PR:

- The `solana_transfer_swap` function has been modified to return instructions instead of creating transactions.
- The `solana_send_funds_to_user` function has been modified to return instrutions instead of creating transactions.
- The `transfer_spl20` function has been modified to return instructions instead of creating transactions.
- Added a new `jupiter_swap` function has been modified to return instructions instead of directly creating the Jupiter swap.
- All transactions are collected into a single combined transaction bundle inside the `handle_solana_execution` function.
- The Jito bundle is executed atomically using the Jito client.
- If the Jito bundle does not succeed, we fall back to the old way of executing individual transactions via RPC.
- Made use of various provided constants instead of using string literals.
- The `amount_in -= amount_in / 1000` calculation is used to get the final `token_in` quote.
- Improved error handling and log messages.
- Improved the way that token associated accounts are created (dynamically discover token program ID).